### PR TITLE
Fix exercise formatting for loops gone wrong.

### DIFF
--- a/_episodes/03-control-structures.md
+++ b/_episodes/03-control-structures.md
@@ -253,8 +253,8 @@ changes it to green).  If we define `sum = 0` now we can't use the function `sum
 > > 2. The Boolean value is set to False the loop will never be executed.
 > > 3. When i does equal 10 the expression is False and the loop does not execute so we have only summed 1 to 9
 > > 4. Because you cannot guarantee the internal representation of Float, you should never try to compare them for equality. In this particular case the i never 'equals' n and so the loop never ends. - If you did try running this, you can stop it using `Ctrl+c` in a terminal or going to the kernel menu of a notebook and choosing interrupt.
-> > {: .solution}
-> {: .challenge}
+> {: .solution}
+{: .challenge}
 
 
 


### PR DESCRIPTION
An extra > made it not render the exercise solution
properly.

Please delete the text below before submitting your contribution. 