### PR TITLE
Format Ep 2 exercise correctly

### DIFF
--- a/_episodes/02-basics.md
+++ b/_episodes/02-basics.md
@@ -451,7 +451,7 @@ bool_val is True
 >     print("bool_val3 is",bool_val3)
 > ~~~
 > {: .language-python}
->
+{: .challenge}
 
 > ## Exercise
 >


### PR DESCRIPTION
The challenge formatting instruction was left off an exercise
in episode two. This fixes that formatting.

Addresses issue #45 