### PR TITLE
Add syntax highlighting to an ep 3 exercise.

### DIFF
--- a/_episodes/03-control-structures.md
+++ b/_episodes/03-control-structures.md
@@ -119,7 +119,7 @@ In the last example, notice that in Python the operator used to check equality i
 > > if a <= b :
 > >     print(b, "is bigger than or equal to ", a)
 > > ~~~
-> >
+> > {: .language-python}
 > {: .solution}
 {: .challenge}
 


### PR DESCRIPTION
The challenge formatting instruction was left off an exercise
in episode two. This fixes that formatting.

Addresses issue #46  