### PR TITLE
Fix formatting of EP 7 (JSON) exercise.

### DIFF
--- a/_episodes/07-json.md
+++ b/_episodes/07-json.md
@@ -93,13 +93,13 @@ dict_values(['Peter', ['John', 'Jane', 'Jack'], {'home': '0102345678', 'mobile':
 > >                           'Work' : {'Addressline1' : '19 Orford Road.', 'Addressline2' : 'London', 'PostCode' : 'EC4J 3XY'}
 > >                           }
 > > 
-> print(personDict['Addresses']['Work']['PostCode'])
+> > print(personDict['Addresses']['Work']['PostCode'])
 > > 
 > > for child in personDict['Children']:
 > >     print(child)
 > >     
 > > ~~~
-> > 
+> > {: .language-python}
 > {: .solution}
 {: .challenge}
 


### PR DESCRIPTION
The solution to this exercise did not have syntax highlighting.

Addresses issue #47 