### PR TITLE
Fix broken link from https://datacarpentry.org/lessons/

### DIFF
--- a/reference.md
+++ b/reference.md
@@ -1,6 +1,5 @@
 ---
 layout: reference
-permalink: /reference/
 ---
 
 ## Glossary
@@ -108,7 +107,7 @@ tuple
     but cannot be modified.
 
 variable
-:   a named quantity that can store a value, a variable can store any type, but always one type for a given value.  
+:   a named quantity that can store a value, a variable can store any type, but always one type for a given value.
 
 
 


### PR DESCRIPTION
Discussion in datacarpentry/datacarpentry.github.io#531 identified a problem with broken links from https://datacarpentry.org/lessons/ to the reference and/or instructor notes pages for some lessons. This PR fixes the problem for the Reference page of this lesson, by unsetting the permalink on `reference.md`.