### PR TITLE
make lesson suitable for teaching with locally-built (serverless) pages 

### DIFF
--- a/_extras/about.md
+++ b/_extras/about.md
@@ -1,6 +1,4 @@
 ---
-layout: page
 title: About
-permalink: /about/
 ---
 {% include carpentries.html %}

--- a/_extras/discuss.md
+++ b/_extras/discuss.md
@@ -1,6 +1,4 @@
 ---
-layout: page
 title: Discussion
-permalink: /discuss/
 ---
 FIXME

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -1,7 +1,5 @@
 ---
-layout: page
-title: "Instructor Notes"
-permalink: /guide/
+title: Instructor Notes
 ---
 
 ## Setup

--- a/index.md
+++ b/index.md
@@ -36,5 +36,5 @@ This is an introduction to Python designed for participants with no programming 
 
 > ## For Instructors
 > If you are teaching this lesson in a workshop, please see the
-> [Instructor notes](guide/).
+> [Instructor notes](guide/index.html).
 {: .prereq}

--- a/index.md
+++ b/index.md
@@ -1,9 +1,10 @@
 ---
 layout: lesson
-maintainers: 
+maintainers:
  - Stephen Childs
  - Geoffrey Boushey
 root: .
+permalink: index.html
 ---
 
 

--- a/setup.md
+++ b/setup.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Setup
 ---
 
@@ -15,9 +14,9 @@ The [Anaconda](https://www.anaconda.com/download/) distribution of Python will a
 2.	There will be two options, one for Python 2.x and another for Python 3.x. We will take the Python 3.x option. Python 2.x will eventually be phased out but is still provided for backward compatibility with some older optional Python modules. The majority of popular modules have been converted to work with Python 3.x. The actual value of x will vary depending on when you download. At the time of writing I am being offered Python 3.6 or Python 2.7.
 3.	For Windows and Linux there is the option of either a 64 bit (default) download or a 32 bit download. Unless you know that you have an old 32 bit pc you should choose the 64 bit installer.
 4.	Run the downloaded installer program. Accept the default settings until you are given the option to add Anaconda to your environmental Path variable. Despite the recommendation not to and the subsequent warning, you should select this option. This will make it easier later on to start Jupyter notebooks from any location.
-5.	The installation can take a few minutes. When finished you should be able to open a cmd prompt (Type cmd from Windows start and into the cmd window type python. You should get a display similar to that below.  
+5.	The installation can take a few minutes. When finished you should be able to open a cmd prompt (Type cmd from Windows start and into the cmd window type python. You should get a display similar to that below.
 ![Python Install](/fig/Python_install_1.png)
-6.	The `>>>` prompt tells you that you are in the Python environment. You can exit Python with the `exit()` command.  
+6.	The `>>>` prompt tells you that you are in the Python environment. You can exit Python with the `exit()` command.
 
 
 


### PR DESCRIPTION
See discussion here for more background: https://github.com/datacarpentry/datacarpentry.github.io/issues/542

In short, some Carpentries lessons use the path `/guide/` for their Instructor Notes page and others use `/guide/index.html` (the default defined in `_config.yml`). This PR removes permalinks with a trailing slash from the YAML front matter of the Instructor Notes (`_extras/guide.md`) and other Extras files, consistent with new lessons created with [the lesson template](https://github.com/carpentries/styles/). Although there's no functional difference in the online versions of the lesson pages, pages with a trailing slash in the permalink will result in **broken links in the version of the lesson built locally**. We'd like local builds to be usable e.g. in workshops taking place at locations with limited or unreliable Internet access. 

Keeping the paths to these files consistent will also help us avoid broken links on the [Data Carpentry Lessons page](https://datacarpentry.org/lessons/), and ensure that equivalent paths in new lessons created with the template are consistent with previously-developed lessons like this one.

I did a sweep through the lesson and adjusted internal links as part of this PR. When this is merged, I'll also make sure the link on https://datacarpentry.org/lessons/ to the Instructor Notes page isn't broken, and make another sweep through the lesson pages too. 

Finally, I also removed the `layout` field from several pages, as the default layout is already set for Episodes and Extras pages in `_config.yml`.