### PR TITLE
Update 02-basics.md

### DIFF
--- a/_episodes/02-basics.md
+++ b/_episodes/02-basics.md
@@ -388,7 +388,7 @@ True
 If you need to refer to a specific element (character) in a string,
 you can do so by specifying the index of the character in `[]`
 you can also use indexing to select a substring of the string. In Python, 
-indexes begin with `0` (see [Index Operator: Working with the Characters of a String](http://interactivepython.org/runestone/static/CS152f17/Strings/IndexOperatorWorkingwiththeCharactersofaString.html) for a visual).
+indexes begin with `0` (see [Index Operator: Working with the Characters of a String](http://www.interactivepython.org/courselib/static/thinkcspy/Strings/IndexOperatorWorkingwiththeCharactersofaString.html) for a visual).
 
 ~~~
 myString = "The quick brown fox"


### PR DESCRIPTION
Fixes #113

In 
https://datacarpentry.org/python-socialsci/02-basics/index.html
https://github.com/datacarpentry/python-socialsci/edit/gh-pages/_episodes/02-basics.md

under the String section
"In Python, indexes begin with 0 (see Index Operator: Working with the Characters of a String for a visual)."
refers to incorrect URL leading to 404 error.

Proposed:
http://www.interactivepython.org/courselib/static/thinkcspy/Strings/IndexOperatorWorkingwiththeCharactersofaString.html

Current (404):
http://interactivepython.org/runestone/static/CS152f17/Strings/IndexOperatorWorkingwiththeCharactersofaString.html

The proposed page auto-redirects to the following and does not require any login. It is on the public web.
https://runestone.academy/runestone/books/published/thinkcspy/Strings/IndexOperatorWorkingwiththeCharactersofaString.html
