### PR TITLE
Fix example for pd.melt

### DIFF
--- a/_episodes/12-long-and-wide.md
+++ b/_episodes/12-long-and-wide.md
@@ -110,7 +110,7 @@ To make the displays more manageable we will use only the first eight 'daily' co
 
 ~~~
 ## using df_papers
-daily_list = df_papers.columns[:8]
+daily_list = df_papers.columns[1:8]
 
 df_daily_papers_long = pd.melt(df_papers, id_vars = ['Id'], value_vars = daily_list)
 


### PR DESCRIPTION
Currently the example causes an error because the "ID" column is in both
id_vars and value_vars. This omits the ID from the value_vars param.

Please delete the text below before submitting your contribution. 

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact Kate Hertweck (k8hertweck@gmail.com).  

---
