### PR TITLE
Add Gemfile from carpentries/lesson-example.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
+
+# Synchronize with https://pages.github.com/versions
+ruby '>=2.7.1'
+
+gem 'github-pages', group: :jekyll_plugins


### PR DESCRIPTION
  - Having a Gemfile allows local rendering with `bundle exec jekyll serve`.