### PR TITLE
Update setup.md

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -18,6 +18,8 @@ title: Setup
 > - [SN7577i_bb.csv](/data/SN7577i_bb.csv)
 > - [SN7577i_c.csv](/data/SN7577i_c.csv)
 > - [SN7577i_d.csv](/data/SN7577i_d.csv)
+> - [SN7577.sqlite](/data/SN7577.sqlite)
+> - [Newspapers.csv](/data/Newspapers.csv)
 {: .prereq}
 
 > ## Software


### PR DESCRIPTION
There are two files missing; SN7577.sqlite and Newspapers.csv. I have proposed to add these two files to download from the setup page.

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
checkout@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
